### PR TITLE
Use 0.0.0/composer-include-files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "barryvdh/laravel-ide-helper": "^2.4",
         "doctrine/dbal": "^2.7",
         "fideloper/proxy": "~3.3",
-        "funkjedi/composer-include-files": "^1.0",
+        "0.0.0/composer-include-files": "^1.0",
         "guzzlehttp/guzzle": "^6.3",
         "johnpbloch/wordpress": "4.9.5",
         "laravel/framework": "5.5.*",


### PR DESCRIPTION
0.0.0/composer-include-files is currently the only known way to include a file first and foremost before any others in Composer, that also works for third-party installs.